### PR TITLE
add PDF action support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Build the camlpdf library as byte code and native code
 PDFMODS = pdfutil pdfio pdftransform pdfunits pdfpaper pdfcryptprimitives pdf pdfcrypt \
-pdfflate pdfcodec pdfwrite pdfgenlex pdfread pdfjpeg pdfops pdfdest \
+pdfflate pdfcodec pdfwrite pdfgenlex pdfread pdfjpeg pdfops pdfdest pdfaction \
 pdfmarks pdfpagelabels pdfpage pdfannot pdffun pdfspace pdfimage pdfafm \
 pdfafmdata pdfglyphlist pdftext pdfstandard14 pdfgraphics pdfshapes pdfdate \
 pdfocg pdfcff pdftype1 pdftruetype pdftype0 pdfmerge

--- a/pdf.ml
+++ b/pdf.ml
@@ -980,4 +980,18 @@ let deep_copy from =
    was_linearized = from.was_linearized;
    saved_encryption = from.saved_encryption}
 
+let add_trailerdict_entry pdf key value =
+  match lookup_direct pdf "/Root" pdf.trailerdict with
+  | None -> raise (PDFError "Bad PDF: no root")
+  | Some catalog ->
+      let catalog' =
+        add_dict_entry catalog key value
+      in
+        let newcatalognum = addobj pdf catalog' in
+          {pdf with
+            root = newcatalognum;
+            trailerdict =
+              add_dict_entry
+                pdf.trailerdict "/Root" (Indirect newcatalognum)}
+
 

--- a/pdf.mli
+++ b/pdf.mli
@@ -267,3 +267,5 @@ val deep_copy : t -> t
 
 val string_of_pdf : (pdfobject -> string) ref
 
+val add_trailerdict_entry : t -> string -> pdfobject -> t
+

--- a/pdfaction.ml
+++ b/pdfaction.ml
@@ -9,9 +9,23 @@ type t =
 let pdfobject_of_action = function
   | NullAction -> Pdf.Null
   | Goto(dest) ->
-    let destobj = Pdfdest.pdfobject_of_destination dest in
-      Pdf.Dictionary ["/Type", Pdf.Name "/Action"; "/S", Pdf.Name "/GoTo"; "/D", destobj]
+      let destobj = Pdfdest.pdfobject_of_destination dest in
+      Pdf.Dictionary [
+        ("/Type", Pdf.Name "/Action");
+        ("/S"   , Pdf.Name "/GoTo");
+        ("/D"   , destobj);
+      ]
+
   | GotoName(destname) ->
-      Pdf.Dictionary ["/Type", Pdf.Name "/Action"; "/S", Pdf.Name "/GoTo"; "/D", Pdf.Name ("/" ^ destname)]
+      Pdf.Dictionary [
+        ("/Type", Pdf.Name "/Action");
+        ("/S"   , Pdf.Name "/GoTo");
+        ("/D"   , Pdf.Name ("/" ^ destname));
+      ]
+
   | Uri(uri) ->
-    Pdf.Dictionary ["/Type", Pdf.Name "/Action"; "/S", Pdf.Name "/URI"; "/URI", Pdf.String uri]
+      Pdf.Dictionary [
+        ("/Type", Pdf.Name "/Action");
+        ("/S"   , Pdf.Name "/URI");
+        ("/URI" , Pdf.String uri);
+      ]

--- a/pdfaction.ml
+++ b/pdfaction.ml
@@ -1,0 +1,17 @@
+
+type t =
+  | NullAction
+  | Goto of Pdfdest.t
+  | GotoName of string
+  | Uri  of string
+
+
+let pdfobject_of_action = function
+  | NullAction -> Pdf.Null
+  | Goto(dest) ->
+    let destobj = Pdfdest.pdfobject_of_destination dest in
+      Pdf.Dictionary ["/Type", Pdf.Name "/Action"; "/S", Pdf.Name "/GoTo"; "/D", destobj]
+  | GotoName(destname) ->
+      Pdf.Dictionary ["/Type", Pdf.Name "/Action"; "/S", Pdf.Name "/GoTo"; "/D", Pdf.Name ("/" ^ destname)]
+  | Uri(uri) ->
+    Pdf.Dictionary ["/Type", Pdf.Name "/Action"; "/S", Pdf.Name "/URI"; "/URI", Pdf.String uri]

--- a/pdfaction.mli
+++ b/pdfaction.mli
@@ -1,0 +1,9 @@
+
+type t =
+  | NullAction
+  | Goto of Pdfdest.t
+  | GotoName of string
+  | Uri  of string
+
+
+val pdfobject_of_action : t -> Pdf.pdfobject

--- a/pdfmarks.mli
+++ b/pdfmarks.mli
@@ -4,7 +4,8 @@
 type t =
   {level : int;
    text : string;
-   target : Pdfdest.t;
+   dest : Pdfdest.t;
+   action : Pdfaction.t;
    isopen : bool}
 
 (** Debug string from a bookmark. *)

--- a/pdfmerge.ml
+++ b/pdfmerge.ml
@@ -54,9 +54,9 @@ let merge_bookmarks changes pdfs ranges pdf =
             | Pdfdest.OtherDocPageNumber _ -> 0
             | Pdfdest.PageObject i -> i
       in
-        let objnum = pageobjectnumber_of_target mark.Pdfmarks.target in
+        let objnum = pageobjectnumber_of_target mark.Pdfmarks.dest in
           (*Printf.printf "Considering objnum %i for inclusion...\n" objnum;*)
-          if mem objnum oldnums || mark.Pdfmarks.target = Pdfdest.NullDestination (* If this bookmark is to be included... *)
+          if mem objnum oldnums || mark.Pdfmarks.dest = Pdfdest.NullDestination (* If this bookmark is to be included... *)
             then
               let change_target_destinationpage target n =
                 let change_targetpage = function
@@ -75,10 +75,10 @@ let merge_bookmarks changes pdfs ranges pdf =
                   | Pdfdest.FitBV (t, a) -> Pdfdest.FitBV (change_targetpage t, a)
               in
                 Some
-                  {mark with Pdfmarks.target =
-                     if mark.Pdfmarks.target = Pdfdest.NullDestination
+                  {mark with Pdfmarks.dest =
+                     if mark.Pdfmarks.dest = Pdfdest.NullDestination
                        then Pdfdest.NullDestination
-                       else change_target_destinationpage mark.Pdfmarks.target (lookup_failnull objnum changes)}
+                       else change_target_destinationpage mark.Pdfmarks.dest (lookup_failnull objnum changes)}
            else
              None
       in

--- a/pdfpage.ml
+++ b/pdfpage.ml
@@ -801,7 +801,7 @@ let pdf_of_pages ?(retain_numbering = false) basepdf range =
     let fastrefnums = hashtable_of_dictionary (combine refnums (indx refnums)) in
     let table = hashset_of_list range in
       option_map
-        (function m -> if Hashtbl.mem table (pagenumber_of_target ~fastrefnums basepdf m.Pdfmarks.target) then Some m else None)
+        (function m -> if Hashtbl.mem table (pagenumber_of_target ~fastrefnums basepdf m.Pdfmarks.dest) then Some m else None)
         (Pdfmarks.read_bookmarks basepdf)
   in
     let pdf = Pdf.empty () in

--- a/utop/Makefile
+++ b/utop/Makefile
@@ -5,7 +5,7 @@ PDFMODS = ../pdfutil ../pdfio ../pdftransform ../pdfunits ../pdfpaper ../pdf ../
 ../pdfcrypt ../pdfflate ../pdfcodec ../pdfwrite ../pdfgenlex ../pdfread ../pdfjpeg ../pdfops ../pdfdest \
 ../pdfmarks ../pdfpagelabels ../pdfpage ../pdfannot ../pdffun ../pdfspace ../pdfimage ../pdfafm \
 ../pdfafmdata ../pdfglyphlist ../pdftext ../pdfstandard14 ../pdfgraphics ../pdfshapes ../pdfdate \
-../pdfocg ../pdfcff ../pdftype1 ../pdftruetype ../pdftype0 ../pdfmerge
+../pdfocg ../pdfcff ../pdftype1 ../pdftruetype ../pdftype0 ../pdfmerge ../pdfaction
 
 SOURCES = ../flatestubs.c ../rijndael-alg-fst.c ../stubs-aes.c ../sha2.c ../stubs-sha2.c $(foreach x,$(PDFMODS),$(x).ml $(x).mli) pdfutop.ml
 


### PR DESCRIPTION
SATySFi needs the PDF action feature, but camlpdf doesn't have it. Although SATySFi has an implementation in backend/action.ml, I think it shoud be migrated to camlpdf.

In addition, this PR modifies pdfmarks.ml to support PDF action( /A field ).

This PR is related to gfngfn/SATySFi#134.